### PR TITLE
Allow omniauth-oauth2 1.2.0

### DIFF
--- a/omniauth-square.gemspec
+++ b/omniauth-square.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'omniauth-oauth2', '~> 1.1.1'
+  s.add_runtime_dependency 'omniauth-oauth2', '>= 1.1.1', '< 1.3.0'
   s.add_development_dependency 'rspec', '~> 2.7'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'simplecov'


### PR DESCRIPTION
This version was released on July 9, 2014 and is required for several
other providers. I went with a relaxing of the requirement instead of
just a bump in requirement in case some people are locked to 1.1.1 by
another provider. This seems to be the case when using many omniauth
providers -- a conflict in the required versions in other omniauth
libraries.